### PR TITLE
Fixed the Bonjour enable/disable commands' titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,12 +628,12 @@ defaults write com.apple.QuickTimePlayerX MGPlayMovieOnOpen 1
 
 ### Bonjour
 
-#### Disable Bonjour
+#### Enable Bonjour
 ```bash
 defaults write /System/Library/LaunchDaemons/com.apple.mDNSResponder ProgramArguments -array "/usr/sbin/mDNSResponder" "-launchd"
 ```
 
-#### Enable Bonjour
+#### Disable Bonjour
 ```bash
 defaults write /System/Library/LaunchDaemons/com.apple.mDNSResponder ProgramArguments -array-add "-NoMulticastAdvertisements"
 ```


### PR DESCRIPTION
According to https://raymii.org/s/snippets/OS_X_Turn_Bonjour_off_or_on_via_the_command_line.html there is a confusion between the Bonjour's enable and disable commands