### PR TITLE
Simplify "Show Wi-Fi Network Passwords" to use built-in flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ defaults read /Library/Preferences/SystemConfiguration/com.apple.airport.prefere
 #### Show Wi-Fi Network Passwords
 Exchange SSID with the SSID of the access point you wish to query the password from.
 ```bash
-security find-generic-password -ga "SSID" | grep "password:"
+security find-generic-password -a "SSID" -gw
 ```
 
 


### PR DESCRIPTION
Rather than `grep`ing for `password:`, we can simply use the `-w` flag.

```bash
> security find-generic-password -h
    ...
    -w  Display only the password on stdout
    ...
```