### PR TITLE
Mavericks wallpaper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,16 @@ defaults write com.apple.universalaccess reduceTransparency -bool false
 
 #### Set Wallpaper
 
-For OSX pre-Mavericks: 
+For up to Mountain Lion: 
 
 ```bash
 osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/path/to/picture.jpg"'
 ```
 
-For OSX pos-Mavericks:
+Since Mavericks:
 
 ```bash
 sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '/path/to/picture.jpg'" && killall Dock
-}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,11 @@ For OSX pre-Mavericks:
 osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/path/to/picture.jpg"'
 ```
 
-For OSX pos-Mavericks: 
+For OSX pos-Mavericks:
 
 ```bash
-function newWallpaper() {
-sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '$1'" && killall Dock
+sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '/path/to/picture.jpg'" && killall Dock
 }
-newWallpaper(/path/to/picture.jpg)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,20 @@ defaults write com.apple.universalaccess reduceTransparency -bool false
 ### Wallpaper
 
 #### Set Wallpaper
+
+For OSX pre-Mavericks: 
+
 ```bash
 osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/path/to/picture.jpg"'
+```
+
+For OSX pos-Mavericks: 
+
+```bash
+function newWallpaper() {
+sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '$1'" && killall Dock
+}
+newWallpaper(/path/to/picture.jpg)
 ```
 
 


### PR DESCRIPTION
I am proposing adding a new way of changing the wallpaper that works on OSX Machines post-Mavericks. Starting in OSX the settings for the wallpaper is stored in a sqllite database so the currently displayed method doesn't work. 