### PR TITLE
Added FileVault command to restart machine and skip initial unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,15 +910,15 @@ pbpaste | sort | uniq | pbcopy
 
 ### FileVault
 
+#### Automatically Unlock FileVault on Restart
+If FileVault is enabled on the current volume, it restarts the system, bypassing the initial unlock. The command may not work on all systems.
+```bash
+sudo fdesetup authrestart
+```
+
 #### Check FileVault Status
 ```bash
 sudo fdesetup status
-```
-
-#### Restart Computer and Unlock FileVault
-If FileVault is enabled on the current volume, it restarts the system, bypassing the initial unlock.   The command may not work on all systems.
-```bash
-sudo fdesetup authrestart
 ```
 
 ### Information/Reports

--- a/README.md
+++ b/README.md
@@ -915,6 +915,12 @@ pbpaste | sort | uniq | pbcopy
 sudo fdesetup status
 ```
 
+#### Restart Computer and Unlock FileVault
+If FileVault is enabled on the current volume, it restarts the system, bypassing the initial unlock.   The command may not work on all systems.
+```bash
+sudo fdesetup authrestart
+```
+
 ### Information/Reports
 
 #### Generate Advanced System and Performance Report


### PR DESCRIPTION
This command allows users with FileVault protected drives to restart their machine without it prompting for an unlock key at startup. This is especially useful for people working remotely over SSH who do not have physical access to enter the unlock key after a reboot.