### PR TITLE
Fix "Remove Apple Remote Desktop Settings"

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ find /Applications -path '*Contents/_MASReceipt/receipt' -maxdepth 4 -print |\se
 
 #### Remove Apple Remote Desktop Settings
 ```bash
-sudo rm -rf /var/db/RemoteManagement && \
-sudo rm /Library/Preferences/com.apple.RemoteDesktop.plist && \
-rm ~/Library/Preferences/com.apple.RemoteDesktop.plist && \
-sudo rm -r /Library/Application\ Support/Apple/Remote\ Desktop/ && \
-rm -r ~/Library/Application\ Support/Remote\ Desktop/ && \
+sudo rm -rf /var/db/RemoteManagement ; \
+sudo defaults delete /Library/Preferences/com.apple.RemoteDesktop.plist ; \
+defaults delete ~/Library/Preferences/com.apple.RemoteDesktop.plist ; \
+sudo rm -r /Library/Application\ Support/Apple/Remote\ Desktop/ ; \
+rm -r ~/Library/Application\ Support/Remote\ Desktop/ ; \
 rm -r ~/Library/Containers/com.apple.RemoteDesktop
 ```
 


### PR DESCRIPTION
Fix "Remove Apple Remote Desktop Settings" so it doesn't fight with the defaults system and make the commands independent of each other since some of the items being removed may not currently exist