### PR TITLE
Take a delayed screenshot as PNG instead of JPEG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,9 +1109,9 @@ sudo nvram boot-args=""
 ### Screenshots
 
 #### Take Delayed Screenshot 
-Takes a screenshot as JPEG after 3 seconds and displays in Preview.
+Takes a screenshot as PNG after 3 seconds and displays in Preview.
 ```bash
-screencapture -T 3 -t jpg -P delayedpic.jpg
+screencapture -T 3 -t png -P delayedpic.png
 ```
 
 #### Save Screenshots to Given Location


### PR DESCRIPTION
PNGs look sexier, JPEG is less suitable for on-screen content. And HD space doesn't matter as much as it did some time ago.
You can see the difference by taking both screenshots and zooming in just a little bit.