### PR TITLE
AppleScript commands for accessing the current page in Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,9 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 ```
 
-#### Get the current Web Page as Source, Text or URL
+#### Get Current Page Data
+Use ```get source``` or ```get text``` for the html source or text content.
 ```bash
-osascript -e 'tell application "Safari" to get source of current tab of front window'
-osascript -e 'tell application "Safari" to get text of current tab of front window'
 osascript -e 'tell application "Safari" to get URL of current tab of front window'
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ defaults write com.apple.universalaccess reduceTransparency -bool false
 
 #### Set Wallpaper
 
-Up to Mountain Lion: 
+Up to Mountain Lion:
 
 ```bash
 osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/path/to/picture.jpg"'
@@ -159,7 +159,7 @@ defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 ```
 
 #### Get Current Page Data
-Use ```get source``` or ```get text``` for the html source or text content.
+Use `get source` or `get text` for the html source or text content.
 ```bash
 osascript -e 'tell application "Safari" to get URL of current tab of front window'
 ```

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 ```
 
+#### Get the current Web Page as Source, Text or URL
+```bash
+osascript -e 'tell application "Safari" to get source of current tab of front window'
+osascript -e 'tell application "Safari" to get text of current tab of front window'
+osascript -e 'tell application "Safari" to get URL of current tab of front window'
+```
+
 ### Sketch
 
 #### Export Compact SVGs


### PR DESCRIPTION
AppleScript commands for getting the currently displayed page from Safari as text, as html source or its URL.