### PR TITLE
Added systemsetup -setrestartfreeze on

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ sudo systemsetup -setcomputersleep 60
 sudo systemsetup -setcomputersleep Never
 ```
 
-#### Restart Computer if it Freezes
+#### Automatic Restart on System Freeze
 ```bash
 sudo systemsetup -setrestartfreeze on
 ```

--- a/README.md
+++ b/README.md
@@ -598,6 +598,11 @@ sudo systemsetup -setcomputersleep 60
 sudo systemsetup -setcomputersleep Never
 ```
 
+#### Automatically restart Computer if it freezes
+```bash
+sudo systemsetup -setrestartfreeze on
+```
+
 #### Enable Chime when Charging
 Play iOS charging sound when MagSafe is connected.
 ```bash

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ sudo systemsetup -setcomputersleep 60
 sudo systemsetup -setcomputersleep Never
 ```
 
-#### Automatically restart Computer if it freezes
+#### Restart Computer if it Freezes
 ```bash
 sudo systemsetup -setrestartfreeze on
 ```


### PR DESCRIPTION
Macs may be reliable, but they have been known to freeze up on occasion. If you'd rather not deal with having to manually force a shutdown, you can use this Terminal command to make OS X instantly reboot on a freeze.