### PR TITLE
iTunes: Added info on restoring default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ rm -r ~/Library/Containers/com.apple.RemoteDesktop
 ```bash
 launchctl unload -w /System/Library/LaunchAgents/com.apple.rcd.plist
 ```
+To reverse this and restore default behavior:
+```bash
+launchctl load -w /System/Library/LaunchAgents/com.apple.rcd.plist
+```
 
 ### Safari
 


### PR DESCRIPTION
The "Stop Responding to the Keyboard Media Keys" tip was great - but later on, I wanted to re-enable it. Replacing `unload` with `load` does the trick to restore the default behavior!