### PR TITLE
Use a shorter and more memorable command for 'show external ip'

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ sudo lsof -i :80
 
 #### Show External IP Address
 ```bash
-dig +short myip.opendns.com @resolver1.opendns.com
+curl ifconfig.pro
 ```
 
 ### Wi-Fi


### PR DESCRIPTION
Does what it says on the tin.

On another note, the very top of the readme says: "A curated list of shell commands and tools specific to OS X."...... so should this command even be here at all as it is not OSX specific?