### PR TITLE
Suggested command to toggle "Quit Finder" menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,18 @@ killall Finder
 
 ### Layout
 
+#### Show "Quit Finder" Menu Item
+Makes possible to see Finder menu item "Quit Finder" with default shortcut <kbd>Cmd</kbd> + <kbd>Q</kbd>
+```bash
+# Enable
+defaults write com.apple.finder QuitMenuItem -bool true && \ 
+killall Finder
+
+# Disable (Default)
+defaults write com.apple.finder QuitMenuItem -bool false && \
+killall Finder
+```
+
 #### Smooth Scrolling
 Useful if you’re on an older Mac that messes up the animation.
 ```bash


### PR DESCRIPTION
Tested on my Mac OS since Yosemite till now (10.11.3).

<img width="948" alt="screenshot 2016-02-29 20 29 03" src="https://cloud.githubusercontent.com/assets/2131633/13406311/0c1df15a-df23-11e5-842f-49425ccb5e05.png">

@herrbischoff please review.