### PR TITLE
Add Codeface to Terminal Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,7 @@ chsh -s $(brew --prefix)/bin/zsh
 ### Terminal Fonts
 
 - [Anonymous Pro](http://www.marksimonson.com/fonts/view/anonymous-pro) - A family of four fixed-width fonts designed with coding in mind.
+- [Codeface](https://github.com/chrissimpkins/codeface) - A gallery and repository of monospaced fonts for developers.
 - [DejaVu Sans Mono](http://dejavu-fonts.org/wiki/Main_Page) - A font family based on the Vera Fonts.
 - [Hack](http://sourcefoundry.org/hack/) - Hack is hand groomed and optically balanced to be your go-to code face.
 - [Inconsolata](http://levien.com/type/myfonts/inconsolata.html) -  A monospace font, designed for code listings and the like.


### PR DESCRIPTION
Add the Codeface repository to the Terminal Fonts section.

*Note:*
Codeface is not an individual font, but a repo of fonts.
I'm unsure if it's 100% suited for this section; however, I thought to send a pull request anyway, in case it was thought to be useful.
It's also another awesome-project - I don't know if those should link to each other or not.