### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ chsh -s $(brew --prefix)/bin/fish
 shell for OS X, Linux, and the rest of the family.
 - [Fisherman](http://fisherman.sh) - A blazing fast, modern plugin manager for Fish.
 - [The Fishshell Framework](https://github.com/oh-my-fish/oh-my-fish) - Provides core infrastructure to allow you to install packages which extend or modify the look of your shell.
-- [Installation & Configuration Tutorial](https://github.com/ellerbrock/tutorial-fish-shell-setup-osx) - How to Setup Fish Shell with Fisherman, Powerline Fonts, iTerm2 and Budspencer Theme on OS X.
+- [Installation & Configuration Tutorial](https://github.com/ellerbrock/fish-shell-setup-osx) - How to Setup Fish Shell with Fisherman, Powerline Fonts, iTerm2 and Budspencer Theme on OS X.
 
 #### Zsh
 Install the latest version and set as current users' default shell:


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/ellerbrock/tutorial-fish-shell-setup-osx | https://github.com/ellerbrock/fish-shell-setup-osx 
