### PR TITLE
Add Gatekeeper “Anywhere” setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,18 @@ spctl --add /path/to/Application.app
 spctl --remove /path/to/Application.app
 ```
 
+#### Manage Gatekeeper
+```bash
+# Status
+spctl --status
+
+# Enable (Default)
+sudo spctl --master-enable
+
+# Disable
+sudo spctl --master-disable
+```
+
 ### Passwords
 
 #### Generate Secure Password and Copy to Clipboard


### PR DESCRIPTION
This adds the command to enable the “Anywhere” setting of Gatekeeper. In Sierra, this GUI option is no longer present, but Terminal still has it.