### PR TITLE
Add note as to why `srm` might have been removed

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,427 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public: 
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1089,9 +1089,8 @@ spctl --remove /path/to/Application.app
 ### Passwords
 
 #### Generate Secure Password and Copy to Clipboard
-First, install `pwgen` via Homebrew, etc.
 ```bash
-pwgen -Cs 20 1 | tr -d ' ' | tr -d '\n' | pbcopy
+tr -dc A-Za-z0-9_ < /dev/urandom | head -c 20 | pbcopy
 ```
 
 ### Physical Access

--- a/README.md
+++ b/README.md
@@ -1219,6 +1219,12 @@ osascript /path/to/script.scpt
 diff -qr /path/to/folder1 /path/to/folder2
 ```
 
+#### Copy Large File with Progress
+Make sure you have `pv` installed and replace `/dev/rdisk2` with the appropriate write device or file.
+```bash
+FILE=/path/to/file.iso pv -s $(du -h $FILE | awk '/.*/ {print $1}') $FILE | sudo dd of=/dev/rdisk2 bs=1m
+```
+
 #### Restore Sane Shell
 In case your shell session went insane (some script or application turned it into a garbled mess).
 ```bash

--- a/README.md
+++ b/README.md
@@ -687,6 +687,12 @@ atsutil server -shutdown && \
 atsutil server -ping
 ```
 
+#### Get SF Mono Fonts
+You need to download and install Xcode 8 beta for this to work. Afterwards they should be available in all applications.
+```bash
+cp -v /Applications/Xcode-beta.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/Fonts/SFMono-* ~/Library/Fonts
+```
+
 
 ## Functions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > _“You don’t have to know everything. You simply need to know where to find it when necessary.” (John Brunner)_
 
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/herrbischoff/awesome-osx-command-line)
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 If you want to contribute, you are highly encouraged to do so. Please read the [contribution guidelines](contributing.md).
 

--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,9 @@ defaults write com.apple.screensaver askForPassword -int 0
 
 ### Wiping Data
 
+Note: The `srm` command appears to have been removed on MacOS after 10.9. There is a note on an [Apple support page](https://support.apple.com/en-us/HT201949) hinting as to why:
+> With an SSD drive, Secure Erase and Erasing Free Space are not available in Disk Utility. These options are not needed for an SSD drive because a standard erase makes it difficult to recover data from an SSD.
+
 #### Securely Remove File
 ```bash
 srm /path/to/file

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ chsh -s $(brew --prefix)/bin/fish
 shell for OS X, Linux, and the rest of the family.
 - [Fisherman](http://fisherman.sh) - A blazing fast, modern plugin manager for Fish.
 - [The Fishshell Framework](https://github.com/oh-my-fish/oh-my-fish) - Provides core infrastructure to allow you to install packages which extend or modify the look of your shell.
-- [Installation & Configuration Tutorial](https://github.com/ellerbrock/tutorial-fish-shell-setup-osx) - How to Setup Fish Shell with Fisherman, Powerline Fonts, iTerm2 and Budspencer Theme on OS X.
+- [Installation & Configuration Tutorial](https://github.com/ellerbrock/fish-shell-setup-osx) - How to Setup Fish Shell with Fisherman, Powerline Fonts, iTerm2 and Budspencer Theme on OS X.
 
 #### Zsh
 Install the latest version and set as current users' default shell:

--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ spctl --remove /path/to/Application.app
 
 #### Generate Secure Password and Copy to Clipboard
 ```bash
-tr -dc A-Za-z0-9_ < /dev/urandom | head -c 20 | pbcopy
+LC_ALL=C tr -dc "[:alpha:][:alnum:]" < /dev/urandom | head -c 20 | pbcopy
 ```
 
 ### Physical Access

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For more terminal shell goodness, please also see this list's sister list [Aweso
 	- [Date and Time](#date-and-time)
     - [FileVault](#filevault)
     - [Information/Reports](#informationreports)
+    - [Install OS](#install-os)
     - [Kernel Extensions](#kernel-extensions)
     - [LaunchAgents](#launchagents)
     - [LaunchServices](#launchservices)
@@ -1286,6 +1287,20 @@ sudo fdestatus disable
 #### Generate Advanced System and Performance Report
 ```bash
 sudo sysdiagnose -f ~/Desktop/
+```
+
+### Install OS
+
+#### Create Bootable Installer
+```bash
+# El Capitan
+sudo /Applications/Install\ OS\ X\ El\ Capitan.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume --applicationpath /Applications/Install\ OS\ X\ El\ Capitan.app
+
+# Yosemite
+sudo /Applications/Install\ OS\ X\ Yosemite.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume --applicationpath /Applications/Install\ OS\ X\ Yosemite.app
+
+# Mavericks
+sudo /Applications/Install\ OS\ X\ Mavericks.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume --applicationpath /Applications/Install\ OS\ X\ Mavericks.app
 ```
 
 ### Kernel Extensions

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ brew install macvim --HEAD --with-cscope --with-lua --with-override-system-vim -
 Install the development version of this modern Vim drop-in alternative via Homebrew.
 ```bash
 brew tap neovim/neovim && \
-brew install --HEAD neovim
+brew install neovim
 ```
 
 ### Xcode

--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,12 @@ osascript /path/to/script.scpt
 diff -qr /path/to/folder1 /path/to/folder2
 ```
 
+#### Restore Sane Shell
+In case your shell session went insane (some script or application turned it into a garbled mess).
+```bash
+stty sane
+```
+
 #### Restart
 ```bash
 sudo reboot

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ For more terminal shell goodness, please also see this list's sister list [Aweso
 - [Backup](#backup)
     - [Time Machine](#time-machine)
 - [Developer](#developer)
-    - [App Icons](#app-icons)
     - [Vim](#vim)
     - [Xcode](#xcode)
 - [Disks and Volumes](#disks-and-volumes)

--- a/README.md
+++ b/README.md
@@ -1194,6 +1194,11 @@ osascript /path/to/script.scpt
 
 ### Basics
 
+#### Compare Two Folders
+```bash
+diff -qr /path/to/folder1 /path/to/folder2
+```
+
 #### Restart
 ```bash
 sudo reboot

--- a/README.md
+++ b/README.md
@@ -451,6 +451,13 @@ defaults delete com.apple.dock && \
 killall Dock
 ```
 
+#### Resize
+Fully resize your Dock's body. To resize change the `0` value as an integer.
+```bash
+defaults write com.apple.dock tilesize -int 0 && \
+killall Dock
+```
+
 #### Scroll Gestures
 Use your touchpad or mouse scroll wheel to interact with Dock items. Allows you to use an upward scrolling gesture to open stacks. Using the same gesture on applications that are running invokes Exposé/Mission Control.
 ```bash
@@ -480,7 +487,6 @@ killall Dock
 defaults write com.apple.dock showhidden -bool false && \
 killall Dock
 ```
-
 
 ## Documents
 

--- a/README.md
+++ b/README.md
@@ -1632,6 +1632,7 @@ chsh -s $(brew --prefix)/bin/zsh
 - [Inconsolata](http://levien.com/type/myfonts/inconsolata.html) -  A monospace font, designed for code listings and the like.
 - [Input](http://input.fontbureau.com) - A flexible system of fonts designed specifically for code.
 - [Meslo](https://github.com/andreberg/Meslo-Font) - Customized version of Apple's Menlo font.
+- [Operator Mono](http://www.typography.com/fonts/operator/overview/) - A surprisingly usable alternative take on a monospace font (commercial).
 - [Powerline Fonts](https://github.com/powerline/fonts) - Repo of patched fonts for the Powerline plugin.
 - [Source Code Pro](https://adobe-fonts.github.io/source-code-pro/) - A monospaced font family for user interfaces and coding environments.
 

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ killall Finder
 Makes possible to see Finder menu item "Quit Finder" with default shortcut <kbd>Cmd</kbd> + <kbd>Q</kbd>
 ```bash
 # Enable
-defaults write com.apple.finder QuitMenuItem -bool true && \ 
+defaults write com.apple.finder QuitMenuItem -bool true && \
 killall Finder
 
 # Disable (Default)
@@ -1535,6 +1535,7 @@ chsh -s $(brew --prefix)/bin/fish
 
 - [Homepage](http://fishshell.com) - A smart and user-friendly command line
 shell for OS X, Linux, and the rest of the family.
+- [fin](https://github.com/fishery/fin) - One-file, no-configuration, concurrent plugin manager for the fish shell.
 - [Fisherman](http://fisherman.sh) - A blazing fast, modern plugin manager for Fish.
 - [The Fishshell Framework](https://github.com/oh-my-fish/oh-my-fish) - Provides core infrastructure to allow you to install packages which extend or modify the look of your shell.
 

--- a/README.md
+++ b/README.md
@@ -279,27 +279,20 @@ sudo defaults write /System/Library/Launch Daemons/com.apple.backupd-auto StartI
 #### Local Backups
 Whether Time Machine performs local backups while the Time Machine backup volume is not available.
 ```bash
-# Disable
-sudo tmutil disablelocal
+# Status
+defaults read /Library/Preferences/com.apple.TimeMachine MobileBackups
 
 # Enable (Default)
 sudo tmutil enablelocal
+
+# Disable
+sudo tmutil disablelocal
 ```
 
 #### Prevent Time Machine from Prompting to Use New Hard Drives as Backup Volume
 ```bash
-defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
 ```
-
-#### Set Status
-```bash
-# Disable Local Time Machine Backups
-hash tmutil &> /dev/null && sudo tmutil disablelocal
-
-# Enable Local Time Machine Backups (Default)
-hash tmutil &> /dev/null && sudo tmutil enablelocal
-```
-
 
 ## Developer
 

--- a/README.md
+++ b/README.md
@@ -1029,9 +1029,9 @@ networksetup -setairportpower en0 on
 
 ## Package Managers
 
-- [Fink](http://www.finkproject.org) - The full world of Unix Open Source software for Darwin.
-- [Homebrew](http://brew.sh) - The missing package manager for OS X.
-- [MacPorts](https://www.macports.org) - Compile, install and upgrade either command-line, X11 or Aqua based open-source software.
+- [Fink](http://www.finkproject.org) - The full world of Unix Open Source software for Darwin. A little outdated.
+- [Homebrew](http://brew.sh) - The missing package manager for OS X. The most popular choice.
+- [MacPorts](https://www.macports.org) - Compile, install and upgrade either command-line, X11 or Aqua based open-source software. Very clean, it's what I use.
 
 
 ## Printing

--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,18 @@ spctl --add /path/to/Application.app
 spctl --remove /path/to/Application.app
 ```
 
+#### Manage Gatekeeper
+```bash
+# Status
+spctl --status
+
+# Enable (Default)
+sudo spctl --master-enable
+
+# Disable
+sudo spctl --master-disable
+```
+
 ### Passwords
 
 #### Generate Secure Password and Copy to Clipboard

--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ sudo tmutil disablelocal
 sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
 ```
 
+#### Verify Backup
+Beginning in OS X 10.11, Time Machine records checksums of files copied into snapshots. Checksums are not retroactively computed for files that were copied by earlier releases of OS X.
+```bash
+sudo tmutil verifychecksums /path/to/backup
+```
+
 ## Developer
 
 ### Vim

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ defaults write com.apple.Safari IncludeInternalDebugMenu -bool true && \
 defaults write com.apple.Safari IncludeDevelopMenu -bool true && \
 defaults write com.apple.Safari WebKitDeveloperExtrasEnabledPreferenceKey -bool true && \
 defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled -bool true && \
-defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
+defaults write -g WebKitDeveloperExtras -bool true
 ```
 
 #### Get Current Page Data
@@ -512,7 +512,7 @@ chflags hidden /path/to/folder/
 ```
 #### Show All File Extensions
 ```bash
-defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write -g AppleShowAllExtensions -bool true
 ```
 
 #### Show Hidden Files
@@ -541,7 +541,7 @@ chflags nohidden ~/Library
 
 #### Increase Number of Recent Places
 ```bash
-defaults write .GlobalPreferences NSNavRecentPlacesLimit -int 10 && \
+defaults write -g NSNavRecentPlacesLimit -int 10 && \
 killall Finder
 ```
 
@@ -563,10 +563,10 @@ killall Finder
 Useful if you’re on an older Mac that messes up the animation.
 ```bash
 # Disable
-defaults write NSGlobalDomain NSScrollAnimationEnabled -bool false
+defaults write -g NSScrollAnimationEnabled -bool false
 
 # Enable (Default)
-defaults write NSGlobalDomain NSScrollAnimationEnabled -bool true
+defaults write -g NSScrollAnimationEnabled -bool true
 ```
 
 #### Rubberband Scrolling
@@ -580,8 +580,8 @@ defaults write -g NSScrollViewRubberbanding -bool true
 
 #### Expand Save Panel by Default
 ```bash
-defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true && \
-defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
+defaults write -g NSNavPanelExpandedStateForSaveMode -bool true && \
+defaults write -g NSNavPanelExpandedStateForSaveMode2 -bool true
 ```
 
 #### Desktop Icon Visibility
@@ -607,7 +607,7 @@ defaults write com.apple.finder ShowPathbar -bool false
 #### Scrollbar Visibility
 Possible values: `WhenScrolling`, `Automatic` and `Always`.
 ```bash
-defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
+defaults write -g AppleShowScrollBars -string "Always"
 ```
 
 #### Status Bar
@@ -622,7 +622,7 @@ defaults write com.apple.finder ShowStatusBar -bool false
 #### Save to Disk by Default
 Sets default save target to be a local disk, not iCloud.
 ```bash
-defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+defaults write -g NSDocumentSaveNewDocumentsToCloud -bool false
 ```
 
 #### Set Current Folder as Default Search Scope
@@ -639,7 +639,7 @@ defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}"
 #### Set Sidebar Icon Size
 Sets size to 'medium'.
 ```bash
-defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int 2
+defaults write -g NSTableViewDefaultSizeMode -int 2
 ```
 
 ### Metadata Files
@@ -859,7 +859,7 @@ defaults write -g ApplePressAndHoldEnabled -bool true
 #### Key Repeat Rate
 Sets a very fast repeat rate, adjust to taste.
 ```bash
-defaults write NSGlobalDomain KeyRepeat -int 0.02
+defaults write -g KeyRepeat -int 0.02
 ```
 
 
@@ -1063,8 +1063,8 @@ cancel -a -
 
 #### Expand Print Panel by Default
 ```bash
-defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true && \
-defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
+defaults write -g PMPrintingExpandedStateForPrint -bool true && \
+defaults write -g PMPrintingExpandedStateForPrint2 -bool true
 ```
 
 #### Quit Printer App After Print Jobs Complete

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For more terminal shell goodness, please also see this list's sister list [Aweso
     - [App Store](#app-store)
     - [Apple Remote Desktop](#apple-remote-desktop)
     - [Contacts](#contacts)
+    - [Google](#google)
     - [iTunes](#itunes)
     - [Mail](#mail)
     - [Safari](#safari)
@@ -168,6 +169,13 @@ defaults write com.apple.addressbook ABShowDebugMenu -bool true
 
 # Disable (Default)
 defaults write com.apple.addressbook ABShowDebugMenu -bool false
+```
+
+### Google
+
+#### Uninstall Google Update
+```bash
+~/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/ksinstall --nuke
 ```
 
 ### iTunes

--- a/functions.md
+++ b/functions.md
@@ -8,6 +8,10 @@
 
 - [Developer](#developer)
     - [App Icons](#app-icons)
+        - [Create App Icon](#create-app-icon)
+    - [Helper Functions](#helper-functions)
+        - [Ask User for Password](#ask-user-for-password)
+
 - [Finder](#finder)
     - [Get Path of Frontmost Finder Window](#get-path-of-frontmost-finder-window)
     - [Print Files Selected in Finder](#print-files-selected-in-finder)
@@ -21,7 +25,9 @@
 ### App Icons
 
 #### Create App Icon
+
 Function to quickly create an application icon from 1024px master file.
+
 ```bash
 function mkicns() {
     if [[ -z "$@" ]]; then
@@ -43,6 +49,33 @@ function mkicns() {
         rm -r $filename.iconset
     fi
 }
+```
+
+### Helper Functions
+
+#### Ask User for Password
+
+This function will use AppleScript to present a password entry dialog to make
+your scripts a little more user friendly.
+
+```bash
+function gui_password {
+    if [[ -z $1 ]]; then
+        gui_prompt="Password:"
+    else
+        gui_prompt="$1"
+    fi
+    PW=$(osascript <<EOF
+    tell application "System Events"
+        activate
+        text returned of (display dialog "${gui_prompt}" default answer "" with hidden answer)
+    end tell
+EOF
+    )
+
+    echo -n "${PW}"
+}
+
 ```
 
 ## Finder

--- a/functions.md
+++ b/functions.md
@@ -61,22 +61,22 @@ function finder_path {
 }
 ```
 
- ### Print Files Selected in Finder
+### Print Files Selected in Finder
 
- ```bash
- selected() {
-     osascript <<EOT
-         tell application "Finder"
-             set theFiles to selection
-             set theList to ""
-             repeat with aFile in theFiles
-                 set theList to theList & POSIX path of (aFile as alias) & "\n"
-             end repeat
-             theList
-         end tell
- EOT
- }
- ```
+```bash
+selected() {
+    osascript <<EOT
+        tell application "Finder"
+            set theFiles to selection
+            set theList to ""
+            repeat with aFile in theFiles
+                set theList to theList & POSIX path of (aFile as alias) & "\n"
+            end repeat
+            theList
+        end tell
+EOT
+}
+```
 
 ### Set Current Directory's Finder View to Column View
 

--- a/snippets.md
+++ b/snippets.md
@@ -1,0 +1,24 @@
+<img src="https://cdn.rawgit.com/herrbischoff/awesome-osx-command-line/master/assets/logo.svg" width="600">
+
+# Snippets
+
+> An assorted collection of useful Bash-style command chains, ready to cut and paste.  
+> Part of [Awesome OS X Command Line](https://github.com/herrbischoff/awesome-osx-command-line).
+
+## Table of Contents
+
+- [Text Manipulation](#text-manipulation)
+    - [Extract Unique Words from Text File](#extract-unique-words-from-text-file)
+
+
+## Text Manipulation
+
+### Extract Unique Words from Text File
+```bash
+grep -o -E '\w+' <file> | sort -u -f
+```
+
+
+## License
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.


### PR DESCRIPTION
I noticed that 10.12 doesn't have the `srm` utility installed. After a little bit of investigation it would seem that SSD drives wouldn't benefit from it so I have added a note to the "Wiping data" part of the README to help others.