### PR TITLE
Added Update to Folder Path for OSX Sierra Mail v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ set os_version to do shell script "sw_vers -productVersion"
 set mail_version to "V2"
 considering numeric strings
     if "10.10" <= os_version then set mail_version to "V3"
+    if "10.12" < os_version then set mail_version to "V4" # for osx sierra
 end considering
 
 set sizeBefore to do shell script "ls -lnah ~/Library/Mail/" & mail_version & "/MailData | grep -E 'Envelope Index$' | awk {'print $5'}"


### PR DESCRIPTION
Mac Mail is using the folder path ~/Library/Mail/V4/ such that the script here needs to be updated.
The modified script has been checked with my own folder structure (osx sierra 10.12.3) and it worked.

Source:
http://brettterpstra.com/2015/10/27/vacuuming-mail-dot-app-on-el-capitan/

Another variant is documented here:
http://brettterpstra.com/2012/09/15/vacuuming-your-mail-app-index-still-works-wonders/
But I cannot verify which mac mail version (v3 or v4) is used on El Capitan.