### PR TITLE
Note difference between Homebrew and MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,8 +1053,8 @@ networksetup -setairportpower en0 on
 ## Package Managers
 
 - [Fink](http://www.finkproject.org) - The full world of Unix Open Source software for Darwin. A little outdated.
-- [Homebrew](https://brew.sh) - The missing package manager for OS X. The most popular choice.
-- [MacPorts](https://www.macports.org) - Compile, install and upgrade either command-line, X11 or Aqua based open-source software. Very clean, it's what I use.
+- [Homebrew](https://brew.sh) - The missing package manager for OS X. The most popular choice. Tries to resue system libraries as much as possible.
+- [MacPorts](https://www.macports.org) - Compile, install and upgrade either command-line, X11 or Aqua based open-source software. Only uses internal dependencies, e.g. other macports. Very clean, it's what I use.
 
 
 ## Printing


### PR DESCRIPTION
This adds a small note about the fundamental difference between the two package managers. Reuse vs. ensuring compatibility.

I tried to be neutral and just point out the difference, but I'm not sure if I succeeded or not, feedback is much welcome.

On that note, perhaps the personal note from the original author should be removed, as this serves as a guide for many new and old Mac tinkerers? I mean that whoever reads this should make an informed decision, and probably do their research, as you are pretty much stuck with your choice of package manager.

---

Personally I've used both MacPorts and Homebrew, and tried Fink. I found brew to be nicer, since it reuses the existing libraries, but that's just personal taste and MacPorts did a fine job when I did use it.