### PR TITLE
changed Vacuum Mail Index to work with macos 10.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ tell application "Mail" to quit
 set os_version to do shell script "sw_vers -productVersion"
 set mail_version to "V2"
 considering numeric strings
-    if "10.10" <= os_version then set mail_version to "V3"
+	if "10.10" ≤ os_version then set mail_version to "V3"
+	if "10.12" ≤ os_version then set mail_version to "V4"
 end considering
 
 set sizeBefore to do shell script "ls -lnah ~/Library/Mail/" & mail_version & "/MailData | grep -E 'Envelope Index$' | awk {'print $5'}"

--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ atsutil server -ping
 #### Get SF Mono Fonts
 You need to download and install Xcode 8 beta for this to work. Afterwards they should be available in all applications.
 ```bash
-cp -v /Applications/Xcode-beta.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/Fonts/SFMono-* ~/Library/Fonts
+cp -v /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/Fonts/SFMono-* ~/Library/Fonts
 ```
 
 


### PR DESCRIPTION
This will now work with Sierra machines with the change of the DB location to V4.

Also changed the string for the San Francisco font being inputed into the main font library of the machine.