### PR TITLE
Add `nettop` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,11 @@ ping -o github.com
 traceroute github.com
 ```
 
+#### Display updated information about used sockets or routes
+```bash
+nettop
+```
+
 ### SSH
 
 #### Remote Login

--- a/README.md
+++ b/README.md
@@ -997,7 +997,7 @@ ping -o github.com
 traceroute github.com
 ```
 
-#### Display updated information about used sockets or routes
+#### Display Updated Information about Used Sockets or Routes
 ```bash
 nettop
 ```


### PR DESCRIPTION
The `nettop` program displays a list of sockets or routes. The counts for network structures are updated periodically.

Very useful if you want to know which program uses what socket.