### PR TITLE
Add top - an Activity Monitor for the Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,12 @@ sudo defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText "
 
 ### Memory Management
 
+
+#### Displays a Sorted List of System Processes
+```bash
+top
+```
+
 #### Purge memory cache
 ```bash
 sudo purge


### PR DESCRIPTION
`top` is a sorted list of System Processes.  Similar to Activity Monitor but displays processes on the terminal.