### PR TITLE
Use screensaver for wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/p
 sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '/path/to/picture.jpg'" && killall Dock
 ```
 
+#### Use Screensaver for Wallpaper
+Note: this prevents normal screensaver activation after a timed amount of inactivity.
+
+```bash
+/System/Library/Frameworks/ScreenSaver.framework/Resources/ScreenSaverEngine.app/Contents/MacOS/ScreenSaverEngine -background &
+
+# Restore Wallpaper and Screensaver Activation
+killall ScreenSaverEngine && sleep 1 && \
+open /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app
+```
 
 ## Applications
 


### PR DESCRIPTION
Updated with option to revert. It's a bit of a mess because normal, timed activation is disabled when it runs as wallpaper, and the screensaver has to be run again to restore proper behavior.