### PR TITLE
Add "Use Backspace/Delete to Go Back a Page" to Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ Other options: `get source`, `get text`.
 osascript -e 'tell application "Safari" to get URL of current tab of front window'
 ```
 
+#### Use Backspace/Delete to Go Back a Page
+```bash
+defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2BackspaceKeyNavigationEnabled -bool YES
+```
+
 ### Sketch
 
 #### Export Compact SVGs


### PR DESCRIPTION
As seen on https://apple.stackexchange.com/questions/167601/why-cant-i-go-back-with-backspace-in-safari-8.

I use this on all my Macs.