### PR TITLE
Added Upterm to the list of alternative terminal apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,7 @@ tput bel
 ### Alternative Terminals
 
 - [iTerm2](https://iterm2.com) - A better Terminal.app.
+- [Upterm](https://github.com/railsware/upterm) - A terminal emulator for the 21st century.
 
 ### Shells
 


### PR DESCRIPTION
From Upterm project page: Upterm (formerly Black Screen) is an IDE in the world of terminals. Strictly speaking, it's both a terminal emulator and an interactive shell based on Electron.

I am not affiliated with Upterm.